### PR TITLE
Add lightweight coding-agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,9 +14,16 @@ This file is a concise entry point for coding agents. It does not replace the re
 - Connect each change to a GitHub issue.
 - Synchronize with `origin/develop`, create a focused feature branch from `develop`, and open a pull request back into `develop`.
 - Do not commit directly to `develop` or `master`, and never force-push shared branches.
+- Coding agents must not merge pull requests; a human maintainer performs merges after the required human reviews and CI checks are complete.
 - Keep the change scoped to its issue. Do not modify other repositories unless the user separately authorizes work there.
 - Use the GitHub issue and pull request as the operational handoff for parallel work. Do not introduce repository-wide task or status files without maintainer agreement.
 - Disclose substantive AI assistance in the pull-request template and state what was independently verified.
+
+## Multi-machine and parallel work
+
+- Before resuming work, fetch the remote state and confirm the current branch, its upstream, and the associated issue and pull-request status. Fast-forward an existing feature branch when possible; if local and remote history diverge, stop and reconcile the histories without force-pushing.
+- Before changing machines or handing work to another collaborator, push a coherent feature-branch state and update the issue or pull request with the remaining work, validation completed, and any unresolved questions. Do not leave the only copy of active work on one machine.
+- Do not edit the same feature branch concurrently on multiple machines or with multiple collaborators. Use separate issue-linked branches for genuinely parallel work and combine them through reviewable pull requests.
 
 ## Validation and generated content
 
@@ -25,6 +32,12 @@ This file is a concise entry point for coding agents. It does not replace the re
 - When documentation is affected, build or render the relevant documentation and inspect the result.
 - Do not edit generated files as if they were authoritative source. Keep source data, generators, committed outputs, and build instructions synchronized as required by the existing workflow.
 - Never bypass failing tests or review safeguards merely to complete a task.
+
+## Release safeguards
+
+- `develop` is the integration branch and `master` is updated only through the periodic release process in [`docs/RELEASE.md`](docs/RELEASE.md).
+- Coding agents must not merge `develop` into `master`, change a release version, publish to TestPyPI or PyPI, create or push release tags, create GitHub releases, or announce a release. A release maintainer must explicitly authorize and perform those operations.
+- Never inspect, expose, commit, or reproduce package-index credentials, API tokens, or other release secrets.
 
 ## Repository boundaries
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,48 +2,30 @@
 
 ## Purpose and authority
 
-This file is a concise entry point for coding agents. It does not replace the
-repository's contributor policies. Before substantive work, read and follow:
+This file is a concise entry point for coding agents. It does not replace the repository's contributor policies. Before substantive work, read and follow:
 
-- [`CONTRIBUTING.md`](CONTRIBUTING.md) for issues, branches, pull requests,
-  setup, and validation;
-- [`docs/good_practices.md`](docs/good_practices.md) for implementation,
-  testing, documentation, and review expectations; and
-- [`docs/ai-assisted-contributions.md`](docs/ai-assisted-contributions.md) for
-  required verification and pull-request disclosure.
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) for issues, branches, pull requests, setup, and validation;
+- [`docs/good_practices.md`](docs/good_practices.md) for implementation, testing, documentation, and review expectations; and
+- [`docs/ai-assisted-contributions.md`](docs/ai-assisted-contributions.md) for required verification and pull-request disclosure.
 
 ## Required workflow
 
 - Inspect `git status` and preserve unrelated work before editing.
 - Connect each change to a GitHub issue.
-- Synchronize with `origin/develop`, create a focused feature branch from
-  `develop`, and open a pull request back into `develop`.
-- Do not commit directly to `develop` or `master`, and never force-push shared
-  branches.
-- Keep the change scoped to its issue. Do not modify neighboring repositories
-  unless the user separately authorizes work there.
-- Use the GitHub issue and pull request as the operational handoff for parallel
-  work. Do not introduce repository-wide task or status files without
-  maintainer agreement.
-- Disclose substantive AI assistance in the pull-request template and state
-  what was independently verified.
+- Synchronize with `origin/develop`, create a focused feature branch from `develop`, and open a pull request back into `develop`.
+- Do not commit directly to `develop` or `master`, and never force-push shared branches.
+- Keep the change scoped to its issue. Do not modify other repositories unless the user separately authorizes work there.
+- Use the GitHub issue and pull request as the operational handoff for parallel work. Do not introduce repository-wide task or status files without maintainer agreement.
+- Disclose substantive AI assistance in the pull-request template and state what was independently verified.
 
 ## Validation and generated content
 
-- Run the smallest relevant checks described in the contributor guides, plus
-  broader tests when the change affects shared behavior.
+- Run the smallest relevant checks described in the contributor guides, plus broader tests when the change affects shared behavior.
 - Run `git diff --check` and review the complete diff before committing.
-- When documentation is affected, build or render the relevant documentation
-  and inspect the result.
-- Do not edit generated files as if they were authoritative source. Keep source
-  data, generators, committed outputs, and build instructions synchronized as
-  required by the existing workflow.
+- When documentation is affected, build or render the relevant documentation and inspect the result.
+- Do not edit generated files as if they were authoritative source. Keep source data, generators, committed outputs, and build instructions synchronized as required by the existing workflow.
 - Never bypass failing tests or review safeguards merely to complete a task.
 
 ## Repository boundaries
 
-QMCSoftware contains QMCPy source, tests, demos, papers, and technical
-documentation. Organization-wide website content belongs in the separate
-`qmcsoftware-website` repository. Coordinate cross-repository changes as
-separate, explicitly scoped tasks and publish dependencies before updating
-their consumers.
+QMCSoftware contains QMCPy source, tests, demos, papers, and technical documentation. Organization-wide website content belongs in the separate `qmcsoftware-website` repository. Coordinate cross-repository changes as separate, explicitly scoped tasks and publish dependencies before updating their consumers.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,49 @@
+# QMCSoftware Agent Guidance
+
+## Purpose and authority
+
+This file is a concise entry point for coding agents. It does not replace the
+repository's contributor policies. Before substantive work, read and follow:
+
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) for issues, branches, pull requests,
+  setup, and validation;
+- [`docs/good_practices.md`](docs/good_practices.md) for implementation,
+  testing, documentation, and review expectations; and
+- [`docs/ai-assisted-contributions.md`](docs/ai-assisted-contributions.md) for
+  required verification and pull-request disclosure.
+
+## Required workflow
+
+- Inspect `git status` and preserve unrelated work before editing.
+- Connect each change to a GitHub issue.
+- Synchronize with `origin/develop`, create a focused feature branch from
+  `develop`, and open a pull request back into `develop`.
+- Do not commit directly to `develop` or `master`, and never force-push shared
+  branches.
+- Keep the change scoped to its issue. Do not modify neighboring repositories
+  unless the user separately authorizes work there.
+- Use the GitHub issue and pull request as the operational handoff for parallel
+  work. Do not introduce repository-wide task or status files without
+  maintainer agreement.
+- Disclose substantive AI assistance in the pull-request template and state
+  what was independently verified.
+
+## Validation and generated content
+
+- Run the smallest relevant checks described in the contributor guides, plus
+  broader tests when the change affects shared behavior.
+- Run `git diff --check` and review the complete diff before committing.
+- When documentation is affected, build or render the relevant documentation
+  and inspect the result.
+- Do not edit generated files as if they were authoritative source. Keep source
+  data, generators, committed outputs, and build instructions synchronized as
+  required by the existing workflow.
+- Never bypass failing tests or review safeguards merely to complete a task.
+
+## Repository boundaries
+
+QMCSoftware contains QMCPy source, tests, demos, papers, and technical
+documentation. Organization-wide website content belongs in the separate
+`qmcsoftware-website` repository. Coordinate cross-repository changes as
+separate, explicitly scoped tasks and publish dependencies before updating
+their consumers.

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,6 +1,7 @@
 CONTRIBUTING.md 
 community.md
 README.md
+AGENTS.md
 QMCPy_Shared_Leadership.md
 demos/
 paper/

--- a/makefile
+++ b/makefile
@@ -308,6 +308,7 @@ uml:
 copydocs:  # mkdocs only looks for content in the docs/ folder, so we have to copy it there
 	@rm -rf docs/paper docs/demos
 	@cp README.md docs/README.md
+	@cp AGENTS.md docs/AGENTS.md
 	@perl -0pi -e 's!\(docs/assets/pep8-badge\.svg\)!\(assets/pep8-badge.svg\)!g' docs/README.md
 	@perl -0pi -e 's!\(docs/qmc-software\.md\)!\(qmc-software.md\)!g' docs/README.md
 	@cp CONTRIBUTING.md docs/CONTRIBUTING.md

--- a/makefile
+++ b/makefile
@@ -309,6 +309,9 @@ copydocs:  # mkdocs only looks for content in the docs/ folder, so we have to co
 	@rm -rf docs/paper docs/demos
 	@cp README.md docs/README.md
 	@cp AGENTS.md docs/AGENTS.md
+	@perl -0pi -e 's!\(docs/good_practices\.md\)!\(good_practices.md\)!g' docs/AGENTS.md
+	@perl -0pi -e 's!\(docs/ai-assisted-contributions\.md\)!\(ai-assisted-contributions.md\)!g' docs/AGENTS.md
+	@perl -0pi -e 's!\(docs/RELEASE\.md\)!\(RELEASE.md\)!g' docs/AGENTS.md
 	@perl -0pi -e 's!\(docs/assets/pep8-badge\.svg\)!\(assets/pep8-badge.svg\)!g' docs/README.md
 	@perl -0pi -e 's!\(docs/qmc-software\.md\)!\(qmc-software.md\)!g' docs/README.md
 	@cp CONTRIBUTING.md docs/CONTRIBUTING.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,6 @@ nav:
   - Community Resources:
     - QMC Software Packages: qmc-software.md
     - PyPI Download Statistics: stats/pypi_downloads.md
-    - Coding Agents: AGENTS.md
   - Components: components.md
   - Contributing: CONTRIBUTING.md
   - Community: community.md
@@ -107,6 +106,7 @@ nav:
       - CI testing and cost control: ci-testing.md
       - QMCPy MPMC compatibility matrix: mpmc-compatibility.md
       - Unit tests on Jupyter Notebooks: booktests.md
+      - Coding Agents: AGENTS.md
     - JOSS 2026 Paper: paper/paper.md
 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,7 @@ nav:
   - Community Resources:
     - QMC Software Packages: qmc-software.md
     - PyPI Download Statistics: stats/pypi_downloads.md
+    - Coding Agents: AGENTS.md
   - Components: components.md
   - Contributing: CONTRIBUTING.md
   - Community: community.md


### PR DESCRIPTION
## Summary

- Issue: Fixes #588
- Algorithmic or API impact: None. This adds repository-level contributor guidance and publishes it through the existing MkDocs documentation system.
- Commands run: `git diff --check`; `make copydocs`; `NO_MKDOCS_2_WARNING=1 JUPYTER_PLATFORM_DIRS=1 mkdocs build`; focused checks of the rendered Coding Agents page and its internal links.

The root `AGENTS.md` directs coding agents to the existing contributor, good-practices, AI-assistance, and release policies. It reinforces the established issue, feature-branch, validation, and PR workflow without replacing those policies. It also makes multi-machine handoffs explicit, prohibits coding agents from merging pull requests, and reserves release operations for human release maintainers.

GitHub issues and pull requests remain the operational handoff for parallel work. The documentation build copies the authoritative root guidance into `docs/`, rewrites repository-root-relative links for the copied page, and keeps the generated copy ignored.

## AI Assistance

- [ ] No substantive AI assistance was used for this PR.
- [x] AI assistance substantively affected this PR, and I describe that use below.

AI tools and affected areas: OpenAI Codex drafted and refined `AGENTS.md`, added the generated-document handling and link rewrites, validated the MkDocs output, and drafted this pull-request description.

- [x] Independent verification performed.

Independent verification: Reviewed the proposed guidance against `CONTRIBUTING.md`, `docs/good_practices.md`, `docs/ai-assisted-contributions.md`, and `docs/RELEASE.md`; verified all referenced paths; confirmed the branch is based on current `origin/develop`; reviewed the complete diff; built the documentation; and checked that the rendered Coding Agents page contains the new safeguards with working policy links.

## Checklist

- [x] I linked the relevant issue or explained why none was needed.
- [x] I added or updated tests, docs, notebooks, or explained why they were not needed. The change is guidance and documentation-build wiring; the complete MkDocs site was built successfully.
- [x] I verified any equations, citations, benchmarks, numerical claims, or external references changed in this PR. None are changed.
- [x] I reviewed AI-assisted content for licensing, provenance, attribution, confidentiality, and security concerns.
- [x] I described any CI, dependency, notebook runtime, or generated artifact changes if applicable. No CI, dependency, or notebook behavior changes; the generated `docs/AGENTS.md` copy is ignored and rebuilt from the root source.
